### PR TITLE
tinkering on adding support for TLS connections for postgres

### DIFF
--- a/refinery_core/Cargo.toml
+++ b/refinery_core/Cargo.toml
@@ -41,6 +41,11 @@ futures = { version = "0.3.16", optional = true }
 tokio-util = { version = "0.6.7", features = ["compat"], optional = true }
 time = { version = "0.3.5", features = ["parsing", "formatting"] }
 
+# support TLS connections for postgres
+# TODO: these should really be optional, yeah??
+openssl = { version = "0.10.38" }
+postgres-openssl = { version = "0.5.0" }
+
 # Flate2 needs to be included for mysql to work
 flate2 = { version = "1.0", default-features = false, features = [ "zlib" ], optional = true}
 

--- a/refinery_core/src/config.rs
+++ b/refinery_core/src/config.rs
@@ -301,6 +301,7 @@ pub(crate) fn build_db_url(name: &str, config: &Config) -> String {
     if let Some(name) = &config.main.db_name {
         url = url + "/" + name;
     }
+
     url
 }
 

--- a/refinery_core/src/drivers/config.rs
+++ b/refinery_core/src/drivers/config.rs
@@ -89,8 +89,7 @@ macro_rules! with_connection {
                         //
                         // As-is, actually supporting the connection string params seems pointless and overly hard.cli
                         // panic!(path);
-                        let use_ssl = true;
-                        if use_ssl {
+                        if (*&$config.ssl_enabled()) {
                           // new code:
                           let mut builder = SslConnector::builder(SslMethod::tls()).unwrap();
                           builder.set_verify(SslVerifyMode::NONE);


### PR DESCRIPTION
I'm not anywhere near happy with this yet, just getting my bearings in this code right now.

I need to figure out where to land between "just support a single `ssl_enabled` flag" and "support all the ssl query params that https://www.postgresql.org/docs/current/libpq-connect.html#id-1.7.3.8.3.6 lists". And how to reconcile the config file approach with the URL approach.

I also have to balance this with the fact that I have basically no idea what I'm doing here in rust. But hey, it's working so far.